### PR TITLE
Initial version of graphql-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Benchmarks of the following GraphQL implementations:
 * .NET: [HotChocolate](https://github.com/ChilliCream/hotchocolate)
 * Python: [Graphene](https://github.com/graphql-python/graphene), [Strawberry](https://github.com/strawberry-graphql/strawberry), [tartiflette](https://github.com/tartiflette/tartiflette)
 * JVM: [Sangria](https://github.com/sangria-graphql/sangria)
-* Ruby: [agoo](https://github.com/ohler55/agoo)
+* Ruby: [agoo](https://github.com/ohler55/agoo), [graphql-ruby](https://graphql-ruby.org/)
 
 Pull requests welcome.
 

--- a/graphql-ruby/Gemfile
+++ b/graphql-ruby/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "rack", "~> 2.2"
+gem "graphql", "~> 2.0"
+gem "puma", "~> 5.6"

--- a/graphql-ruby/Gemfile.lock
+++ b/graphql-ruby/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    graphql (2.0.5)
+    nio4r (2.5.8)
+    puma (5.6.4)
+      nio4r (~> 2.0)
+    rack (2.2.3)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  graphql (~> 2.0)
+  puma (~> 5.6)
+  rack (~> 2.2)
+
+BUNDLED WITH
+   2.3.3

--- a/graphql-ruby/config.ru
+++ b/graphql-ruby/config.ru
@@ -1,0 +1,33 @@
+require 'rack'
+require 'graphql'
+
+class QueryType < GraphQL::Schema::Object
+  field :hello, String
+
+  def hello
+    'world'
+  end
+end
+
+class AppSchema < GraphQL::Schema
+  query QueryType
+end
+
+class RackApp
+  def call(env)
+    request = Rack::Request.new(env)
+
+    if request.request_method == 'POST' && request.path == '/graphql'
+      body           = JSON.parse(request.body.read)
+      query          = body['query']
+
+      result = AppSchema.execute(query,
+                                 variables: {},
+                                 context: {})
+
+      [200, { 'Content-Type' => 'application/json' }, [result.to_json]]
+    end
+  end
+end
+
+run RackApp.new

--- a/run.cr
+++ b/run.cr
@@ -5,6 +5,7 @@ require "json"
 
 b = [
   {"agoo", "ruby", ["main.rb"]},
+  {"graphql-ruby", "puma", ["-w", System.cpu_count.to_s, "-t", "2", "-b", "127.0.0.1:8000"]},
   {"async-graphql", "./target/release/async-graphql", nil},
   {"gqlgen", "./main", nil},
   {"graphene", "pipenv", ["run", "--", "gunicorn", "--log-level", "warning", "-w", System.cpu_count.to_s, "-b", "127.0.0.1:8000", "app:app"]},


### PR DESCRIPTION
This sets up a working version of [graphql-ruby](https://graphql-ruby.org/) with [Puma](https://puma.io/) and [Rack](https://github.com/rack/rack).

Let me know if I need to adapt anything. Wasn't able to run it with `run.cr` yet.