### PR TITLE
Attempt to add Bun/Hono GraphQL server to benchmarks.

### DIFF
--- a/benchmarks.yaml
+++ b/benchmarks.yaml
@@ -193,3 +193,11 @@
       ]
 # broken
 # {"tartiflette", "pipenv", ["run", "--", "python", "app.py"]},
+- id: hono
+  name: Hono
+  url: https://github.com/honojs/graphql-server
+  lang: Bun
+  server: HonoJS
+  run:
+    cmd: bun
+    args: ["index.js"]

--- a/hono/index.js
+++ b/hono/index.js
@@ -1,0 +1,28 @@
+import { Hono } from 'hono';
+import { graphqlServer } from '@honojs/graphql-server';
+import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
+
+export const app = new Hono();
+
+const schema = buildSchema(`
+  type Query {
+    hello: String
+  }
+`);
+
+const rootValue = {
+  hello: async () => 'world',
+};
+
+app.use(
+  '/graphql',
+  graphqlServer({
+    schema,
+    rootValue,
+  })
+);
+
+export default {
+  port: process.env.PORT || 8000,
+  fetch: app.fetch,
+};

--- a/hono/package.json
+++ b/hono/package.json
@@ -1,0 +1,9 @@
+{
+  "main": "index.js",
+  "dependencies": {
+    "graphql": "16.6.0",
+    "hono": "2.7.5",
+    "@honojs/graphql-server": "0.1.1"
+  },
+  "type": "module"
+}

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ pkgs.mkShell {
     ruby
     psmisc
     nim
+    bun
     #crystal # broken undefined reference to `GC_get_my_stackbottom'
   ];
 


### PR DESCRIPTION
I tried to add  a benchmark for the [Hono](https://github.com/honojs/hono) server framework that runs on [Bun](https://github.com/oven-sh/bun). I don't have any experience with Nix. I tried to get it going on my machine, but it looks like one of the Nix packages (`psmisc`) cannot run on Apple Silicon.

It doesn't look to me like bun has support for Node's `cluster` API. It has `spawn`, but it doesn't look like it can be used to run multiple processes that share a port. I doubt that Bun's web server runs multi-core by default. So at the moment, it could be the case that the bun benchmark doesn't use all available cores/threads.

Do you have any recommendations on how I can get the `nix-shell` working on Apple Silicon? Or would you be able to help get this across the finish line? Very curious to see how the benchmark stacks up. Thank you! 🙏