### PR TITLE
Make GraphQL Crystal RFC Compliant

### DIFF
--- a/graphql-crystal/main.cr
+++ b/graphql-crystal/main.cr
@@ -11,6 +11,11 @@ end
 
 schema = GraphQL::Schema.new(Query.new)
 
+# Use a before_all block to set the Date header
+before_all do |env|
+  env.response.headers["Date"] = Time.utc.to_rfc2822
+end
+
 post "/graphql" do |env|
   env.response.content_type = "application/json"
 


### PR DESCRIPTION
> Origin servers MUST include a Date header field in all responses,
   except in these cases:

As per the RFC — https://datatracker.ietf.org/doc/html/rfc2616#section-14.18
